### PR TITLE
Allow users to chose where the date picker gets positioned

### DIFF
--- a/addon/components/date-picker.js
+++ b/addon/components/date-picker.js
@@ -38,6 +38,28 @@ export default Component.extend({
   renderInPlace: false,
 
   /**
+   * Value passed to `ember-basic-dropdown`
+   *
+   * Available values are right|center|left
+   *
+   * @attribute value
+   * @type {String}
+   * @public
+   */
+  horizontalPosition: 'auto',
+
+  /**
+   * Value passed to `ember-basic-dropdown`
+   *
+   * Available values are above|below
+   *
+   * @attribute value
+   * @type {String}
+   * @public
+   */
+  verticalPosition: 'auto',
+
+  /**
    * The default value for the date picker.
    * Can be a value or an array.
    * Note that internally, this will always be converted to an array (if for a sinle-date picker field).

--- a/addon/components/time-picker.js
+++ b/addon/components/time-picker.js
@@ -38,6 +38,28 @@ export default Component.extend({
   renderInPlace: false,
 
   /**
+   * Value passed to `ember-basic-dropdown`
+   *
+   * Available values are right|center|left
+   *
+   * @attribute value
+   * @type {String}
+   * @public
+   */
+  horizontalPosition: 'auto',
+
+  /**
+   * Value passed to `ember-basic-dropdown`
+   *
+   * Available values are above|below
+   *
+   * @attribute value
+   * @type {String}
+   * @public
+   */
+  verticalPosition: 'auto',
+
+  /**
    * The current value of the time picker.
    * Has to be a moment.js object or null.
    *

--- a/addon/templates/components/date-picker.hbs
+++ b/addon/templates/components/date-picker.hbs
@@ -2,6 +2,8 @@
   onOpen=(action 'openDropdown')
   onClose=(action 'closeDropdown')
   renderInPlace=renderInPlace
+  horizontalPosition=horizontalPosition
+  verticalPosition=verticalPosition
 as |dd| }}
 
   {{#dd.trigger class='date-picker__trigger'}}

--- a/addon/templates/components/time-picker.hbs
+++ b/addon/templates/components/time-picker.hbs
@@ -2,6 +2,8 @@
   onOpen=(action 'openDropdown')
   onClose=(action 'closeNext')
   renderInPlace=renderInPlace
+  horizontalPosition=horizontalPosition
+  verticalPosition=verticalPosition
 as |dd| }}
 
   {{#dd.trigger


### PR DESCRIPTION
Makes use of ember-basic-dropdown position attributes.