### PR TITLE
fix(date-picker-month): invoke selectDate action with onclick

### DIFF
--- a/addon/templates/components/date-picker-month-year-select.hbs
+++ b/addon/templates/components/date-picker-month-year-select.hbs
@@ -16,7 +16,7 @@
             type="button"
             class="date-picker__header__select__item
                             {{if (is-equal-month month currentMonth) 'date-picker__header__select__item--current'}}"
-            {{action 'gotoMonth' month monthDropdown}}
+            onclick={{action 'gotoMonth' month monthDropdown}}
           >
             {{moment-format month 'MMMM'}}
           </button>
@@ -44,7 +44,7 @@
             type="button"
             class="date-picker__header__select__item
                               {{if (is-equal-year year currentMonth) 'date-picker__header__select__item--current'}}"
-            {{action 'gotoMonth' year yearDropdown}}
+            onclick={{action 'gotoMonth' year yearDropdown}}
           >
             {{moment-format year 'YYYY'}}
           </button>

--- a/addon/templates/components/date-picker-month.hbs
+++ b/addon/templates/components/date-picker-month.hbs
@@ -17,7 +17,7 @@
         data-date-picker-day="{{date.year}}-{{date.month}}-{{date.day}}"
         disabled={{date.disabled}}
         class={{date-picker-day-classes 'date-picker__day' isDisabled=date.disabled isInRange=date.inRange isToday=(is-equal-day date.date today) isSelected=(is-equal-day date.date selectedDates)}}
-        {{action 'selectDate' date.date}}>
+        onclick={{action 'selectDate' date.date}}>
         {{date.day}}
       </button>
     {{else}}

--- a/addon/templates/components/date-picker-navigation.hbs
+++ b/addon/templates/components/date-picker-navigation.hbs
@@ -2,7 +2,7 @@
   type="button"
   class="date-picker__header__button date-picker__header__button--previous"
   data-test-date-picker-goto-previous-month
-  {{action 'gotoPreviousMonth'}}
+  onclick={{action 'gotoPreviousMonth'}}
 >
   &lt;
 </button>
@@ -11,7 +11,7 @@
   type="button"
   class="date-picker__header__button date-picker__header__button--next"
   data-test-date-picker-goto-next-month
-  {{action 'gotoNextMonth'}}
+  onclick={{action 'gotoNextMonth'}}
 >
   &gt;
 </button>

--- a/addon/templates/components/date-picker.hbs
+++ b/addon/templates/components/date-picker.hbs
@@ -79,7 +79,7 @@ as |dd| }}
             <button
               type="button"
               class="date-picker__options__button {{option.classes}}"
-              {{action option.action option.actionValue}}
+              onclick={{action option.action option.actionValue}}
             >
               {{option.label}}
             </button>

--- a/addon/templates/components/time-picker.hbs
+++ b/addon/templates/components/time-picker.hbs
@@ -54,7 +54,7 @@ as |dd| }}
           <div
             class='time-picker__dropdown__item
             {{if (is-equal selectedOptionIndex i) 'time-picker__dropdown__item--selected'}}'
-            {{action 'selectValue' option.value}}
+            onclick={{action 'selectValue' option.value}}
           >
             {{option.value}}
           </div>


### PR DESCRIPTION
In the context of wormholes, setting an action in this manner: ```<button {{action actionName}}```, will result in the action being ignored by the local context. Or at least, that the issue that I found, when using ```renderInPlace: false``` and a blocked-component. This PR resolved my issue.