### PR TITLE
Added dependent keys on time picker options property

### DIFF
--- a/addon/components/time-picker.js
+++ b/addon/components/time-picker.js
@@ -218,21 +218,28 @@ export default Component.extend({
    * @type {amPm, step, minTime, maxTime}
    * @protected
    */
-  options: computed(function() {
-    let amPm = get(this, 'amPm');
-    let minTime = get(this, 'minTime');
-    let maxTime = get(this, 'maxTime');
-    let step = get(this, 'step');
-    let selectStep = get(this, 'selectStep');
+  options: computed(
+    'step',
+    'amPm',
+    'minTime',
+    'maxTime',
+    'selectStep',
+    function() {
+      let amPm = get(this, 'amPm');
+      let minTime = get(this, 'minTime');
+      let maxTime = get(this, 'maxTime');
+      let step = get(this, 'step');
+      let selectStep = get(this, 'selectStep');
 
-    return {
-      amPm,
-      step,
-      selectStep,
-      minTime: parseTime(minTime),
-      maxTime: parseTime(maxTime)
-    };
-  }),
+      return {
+        amPm,
+        step,
+        selectStep,
+        minTime: parseTime(minTime),
+        maxTime: parseTime(maxTime)
+      };
+    }
+  ),
 
   /**
    * The format which should be used.


### PR DESCRIPTION
I've stumbled across the problem that, if I try to change minTime or maxTime dynamically on the time-picker component, the time range did not update. It turned out that for the options property, no dependent keys were defined. This PR should fix this.