### PR TITLE
feat: Allow to yield named blocks for date-time-picker

### DIFF
--- a/addon/components/date-time-picker.hbs
+++ b/addon/components/date-time-picker.hbs
@@ -1,33 +1,57 @@
 <div class='date-time-picker' ...attributes>
   <span class='date-time-picker__item date-time-picker__item--date'>
-    <DatePicker
-      @value={{@value}}
-      @buttonClasses={{@datePickerClasses}}
-      @buttonDateFormat={{@buttonDateFormat}}
-      @minDate={{@minDate}}
-      @maxDate={{@maxDate}}
-      @disabled={{@disabled}}
-      @renderInPlace={{@renderInPlace}}
-      @horizontalPosition={{@horizontalPosition}}
-      @verticalPosition={{@verticalPosition}}
-      @onChange={{this.updateDate}}
-    />
+    {{#if (has-block 'date')}}
+      {{yield
+        (component
+          'date-picker'
+          value=@value
+          disabled=@disabled
+          onChange=this.updateDate
+        )
+        to='date'
+      }}
+    {{else}}
+      <DatePicker
+        @value={{@value}}
+        @buttonClasses={{@datePickerClasses}}
+        @buttonDateFormat={{@buttonDateFormat}}
+        @minDate={{@minDate}}
+        @maxDate={{@maxDate}}
+        @disabled={{@disabled}}
+        @renderInPlace={{@renderInPlace}}
+        @horizontalPosition={{@horizontalPosition}}
+        @verticalPosition={{@verticalPosition}}
+        @onChange={{this.updateDate}}
+      />
+    {{/if}}
   </span>
 
   <span class='date-time-picker__item date-time-picker__item--time'>
-    <TimePicker
-      @value={{this.timePickerValue}}
-      @disabled={{this.timePickerDisabled}}
-      @minTime={{@minTime}}
-      @maxTime={{@maxTime}}
-      @step={{@step}}
-      @selectStep={{this.selectStep}}
-      @amPm={{@amPm}}
-      @inputClasses={{@timePickerClasses}}
-      @renderInPlace={{@renderInPlace}}
-      @horizontalPosition={{@horizontalPosition}}
-      @verticalPosition={{@verticalPosition}}
-      @onChange={{this.updateTime}}
-    />
+    {{#if (has-block 'time')}}
+      {{yield
+        (component
+          'time-picker'
+          value=this.timePickerValue
+          disabled=@disabled
+          onChange=this.updateTime
+        )
+        to='time'
+      }}
+    {{else}}
+      <TimePicker
+        @value={{this.timePickerValue}}
+        @disabled={{this.timePickerDisabled}}
+        @minTime={{@minTime}}
+        @maxTime={{@maxTime}}
+        @step={{@step}}
+        @selectStep={{@selectStep}}
+        @amPm={{@amPm}}
+        @inputClasses={{@timePickerClasses}}
+        @renderInPlace={{@renderInPlace}}
+        @horizontalPosition={{@horizontalPosition}}
+        @verticalPosition={{@verticalPosition}}
+        @onChange={{this.updateTime}}
+      />
+    {{/if}}
   </span>
 </div>

--- a/addon/components/date-time-picker.js
+++ b/addon/components/date-time-picker.js
@@ -8,21 +8,8 @@ import { assert } from '@ember/debug';
  *
  * Attributes:
  * - value
- * - datePickerClasses
- * - timePickerClasses
- * - buttonDateFormat
- * - amPm
- * - minDate
- * - maxDate
- * - minTime
- * - maxTime
- * - step
- * - selectStep
- * - disabled
  * - ignoreZeroTime
- * - renderInPlace
- * - horizontalPosition
- * - verticalPosition
+ * - disabled
  * - onChange
  */
 export default class DateTimePicker extends Component {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,8 @@
     "ember-classic-decorator": "^2.0.0",
     "ember-cli-babel": "^7.23.1",
     "ember-cli-htmlbars": "^5.6.4",
-    "ember-decorators": "^6.1.1"
+    "ember-decorators": "^6.1.1",
+    "ember-named-blocks-polyfill": "^0.2.4"
   },
   "keywords": [
     "ember-addon",

--- a/tests/dummy/app/styles/_theme.scss
+++ b/tests/dummy/app/styles/_theme.scss
@@ -5,3 +5,7 @@
 h1 {
   margin-top: 2rem;
 }
+
+h2 {
+  margin-top: 1.5rem;
+}

--- a/tests/dummy/app/usage/date-time-picker/template.hbs
+++ b/tests/dummy/app/usage/date-time-picker/template.hbs
@@ -14,7 +14,7 @@
 <DateTimePicker @value={{this.date1}} @onChange={{this.updateDate1}} />
 
 {{#code-block language='handlebars'}}
-&lt;DateTimePicker @value=\{{this.date}} @onChange=\{{this.updateDate}} /&gt;
+  &lt;DateTimePicker @value=\{{this.date}} @onChange=\{{this.updateDate}} /&gt;
 {{/code-block}}
 
 <div class='wrapper'>
@@ -29,8 +29,46 @@
   <h2>
     Disabled
   </h2>
-  <DateTimePicker @value={{this.date1}} @onChange={{this.updateDate1}} @disabled={{true}} />
+  <DateTimePicker
+    @value={{this.date1}}
+    @onChange={{this.updateDate1}}
+    @disabled={{true}}
+  />
 </div>
+
+<h2>
+  With custom date/time picker properties
+</h2>
+<DateTimePicker @value={{this.date1}} @onChange={{this.updateDate1}}>
+  <:date as |DatePicker|>
+    <DatePicker @placeholder='Custom placeholder' />
+  </:date>
+
+  <:time as |TimePicker|>
+    <TimePicker @placeholder='Custom time' />
+  </:time>
+</DateTimePicker>
+
+<p>
+  Note that this uses named blocks, a feature available in Ember 3.25+. 
+  If you want to use it in an app running an older version of Ember, you can install
+  <a href='https://github.com/ember-polyfills/ember-named-blocks-polyfill'>
+    ember-named-blocks-polyfill
+  </a>
+  .
+</p>
+
+{{#code-block language='handlebars'}}
+  &lt;DateTimePicker @value=\{{this.date1}} @onChange=\{{this.updateDate1}}&gt;
+  &lt;:date as |DatePicker|&gt;
+    &lt;DatePicker @placeholder='Custom placeholder' /&gt;
+  &lt;/:date&gt;
+
+  &lt;:time as |TimePicker|&gt;
+    &lt;TimePicker @placeholder='Custom time' /&gt;
+  &lt;/:time&gt;
+&lt;/DateTimePicker&gt;
+{{/code-block}}
 
 <h2>
   Attributes
@@ -97,141 +135,6 @@
     </tr>
     <tr>
       <td>
-        minDate
-      </td>
-      <td>
-        The minimum selectable date. No date before this date will be selectable.
-      </td>
-      <td>
-        {{#code-inline language='javascript'}}
-          null
-        {{/code-inline}}
-      </td>
-    </tr>
-    <tr>
-      <td>
-        maxDate
-      </td>
-      <td>
-        The maximum selectable date. No date after this date will be selectable.
-      </td>
-      <td>
-        {{#code-inline language='javascript'}}
-          null
-        {{/code-inline}}
-      </td>
-    </tr>
-    <tr>
-      <td>
-        minTime
-      </td>
-      <td>
-        The minimum selectable time. No time before this time will be selectable.
-        This can be either a moment.js date, or a parseable string.
-      </td>
-      <td>
-        {{#code-inline language='javascript'}}
-          null
-        {{/code-inline}}
-      </td>
-    </tr>
-    <tr>
-      <td>
-        maxTime
-      </td>
-      <td>
-        The maximum selectable time. No time after this time will be selectable.
-        This can be either a moment.js date, or a parseable string.
-      </td>
-      <td>
-        {{#code-inline language='javascript'}}
-          null
-        {{/code-inline}}
-      </td>
-    </tr>
-    <tr>
-      <td>
-        step
-      </td>
-      <td>
-        The step in which the times can be set, in minutes.
-        Times entered will be rounded to the nearest fitting step.
-      </td>
-      <td>
-        {{#code-inline language='javascript' class='no-wrap'}}
-          1
-        {{/code-inline}}
-      </td>
-    </tr>
-    <tr>
-      <td>
-        selectStep
-      </td>
-      <td>
-        The steps that are available in the dropdown.
-      </td>
-      <td>
-        {{#code-inline language='javascript' class='no-wrap'}}
-          30
-        {{/code-inline}}
-      </td>
-    </tr>
-    <tr>
-      <td>
-        datePickerClasses
-      </td>
-      <td>
-        Classes to add to the date picker button.
-      </td>
-      <td>
-        {{#code-inline language='javascript' class='no-wrap'}}
-          ''
-        {{/code-inline}}
-      </td>
-    </tr>
-    <tr>
-      <td>
-        timePickerClasses
-      </td>
-      <td>
-        Classes to add to the time picker input.
-      </td>
-      <td>
-        {{#code-inline language='javascript' class='no-wrap'}}
-          ''
-        {{/code-inline}}
-      </td>
-    </tr>
-    <tr>
-      <td>
-        buttonDateFormat
-      </td>
-      <td>
-        This is passed through to date-picker.
-      </td>
-      <td>
-        {{#code-inline language='javascript' class='no-wrap'}}
-          'L'
-        {{/code-inline}}
-      </td>
-    </tr>
-    <tr>
-      <td>
-        amPm
-      </td>
-      <td>
-        If the am/pm time format should be used instead of the 24h format.
-        By default, this is computed from the moment.js locale.
-        You can overwrite this if necessary.
-      </td>
-      <td>
-        {{#code-inline language='javascript' class='no-wrap'}}
-          true
-        {{/code-inline}}
-      </td>
-    </tr>
-    <tr>
-      <td>
         disabled
       </td>
       <td>
@@ -240,60 +143,6 @@
       <td>
         {{#code-inline language='javascript'}}
           false
-        {{/code-inline}}
-      </td>
-    </tr>
-    <tr>
-      <td>
-        renderInPlace
-      </td>
-      <td>
-        This is passed through to ember-basic-dropdown.
-        See
-        <a href='https://www.ember-basic-dropdown.com/docs/api-reference'>
-          ember-basic-dropdown docs
-        </a>
-        for details.
-      </td>
-      <td>
-        {{#code-inline language='javascript'}}
-          false
-        {{/code-inline}}
-      </td>
-    </tr>
-    <tr>
-      <td>
-        horizontalPosition
-      </td>
-      <td>
-        This is passed through to ember-basic-dropdown.
-        See
-        <a href='https://www.ember-basic-dropdown.com/docs/api-reference'>
-          ember-basic-dropdown docs
-        </a>
-        for details.
-      </td>
-      <td>
-        {{#code-inline language='javascript'}}
-          'auto'
-        {{/code-inline}}
-      </td>
-    </tr>
-    <tr>
-      <td>
-        verticalPosition
-      </td>
-      <td>
-        This is passed through to ember-basic-dropdown.
-        See
-        <a href='https://www.ember-basic-dropdown.com/docs/api-reference'>
-          ember-basic-dropdown docs
-        </a>
-        for details.
-      </td>
-      <td>
-        {{#code-inline language='javascript'}}
-          'auto'
         {{/code-inline}}
       </td>
     </tr>

--- a/tests/integration/components/date-time-picker-test.js
+++ b/tests/integration/components/date-time-picker-test.js
@@ -9,7 +9,7 @@ import {
 import { selectTime } from 'ember-date-components/test-support/helpers/time-picker';
 import moment from 'moment';
 
-module('Integration | Component | date time picker', function (hooks) {
+module('Integration | Component | date-time-picker', function (hooks) {
   setupRenderingTest(hooks);
 
   test('time picker is disabled if no value is set', async function (assert) {
@@ -271,5 +271,75 @@ module('Integration | Component | date time picker', function (hooks) {
     );
 
     assert.verifySteps(['onChange is called', 'onChange is called']);
+  });
+
+  module('named blocks', function () {
+    test('it allows to yield the components', async function (assert) {
+      let today = moment('2017-05-13');
+
+      this.onChange = function (val) {
+        assert.equal(val.hours(), today.hours(), 'hours remain the same');
+        assert.equal(val.minutes(), today.minutes(), 'minutes remain the same');
+        assert.equal(val.seconds(), today.seconds(), 'seconds remain the same');
+        assert.equal(
+          val.milliseconds(),
+          today.milliseconds(),
+          'ms remain the same'
+        );
+
+        assert.equal(val.year(), 2017, 'year is correct');
+        assert.equal(val.month(), 4, 'month is correct');
+        assert.equal(val.date(), 6, 'date is correct');
+
+        assert.equal(this.value, today, 'the value is not modified');
+
+        assert.step('onChange is called');
+      };
+
+      this.value = today;
+
+      await render(hbs`
+        <DateTimePicker 
+          @value={{this.value}}
+          @onChange={{this.onChange}} 
+        >
+        <:date as |DatePicker|>
+          <DatePicker />
+        </:date>
+
+        <:time as |TimePicker|>
+          <TimePicker />
+        </:time>
+
+        </DateTimePicker>
+      `);
+
+      let datePicker = getDatePicker(this.element);
+      await datePicker.toggle();
+      await datePicker.selectDate(moment('2017-05-06'));
+
+      assert.verifySteps(['onChange is called']);
+    });
+
+    test('it allows to pass arguments to yielded components', async function (assert) {
+      this.onChange = function () {};
+
+      await render(hbs`
+        <DateTimePicker 
+          @onChange={{this.onChange}} 
+        >
+        <:date as |DatePicker|>
+          <DatePicker @placeholder='test 1' />
+        </:date>
+
+        <:time as |TimePicker|>
+          <TimePicker @placeholder='test 2' />
+        </:time>
+
+        </DateTimePicker>
+      `);
+
+      assert.dom('[data-time-picker-toggle-button]').hasText('test 2');
+    });
   });
 });


### PR DESCRIPTION
This allows you to optionally yield the date & time picker components in `<DateTimePicker>` to allow easier customization.

This also solves this: https://github.com/mydea/ember-date-components/pull/161

It uses the new named blocks functionality, available in Ember 3.25+ or via  https://github.com/ember-polyfills/ember-named-blocks-polyfill. (Note that you only need those when using this feature, it does continue to work on older versions as well with the previous functionality).

Syntax for using this:

```hbs
<DateTimePicker @value={{this.date}} @onChange={{this.updateDate}}>
  <:date as |DatePicker|>
    <DatePicker @placeholder='Custom placeholder' />
  </:date>

  <:time as |TimePicker|>
    <TimePicker @placeholder='Custom time' />
  </:time>
</DateTimePicker>
```